### PR TITLE
V2 API: Add default fields for me, support for email endpoint and basic response parsing

### DIFF
--- a/lib/linked_in/api/v2.rb
+++ b/lib/linked_in/api/v2.rb
@@ -9,13 +9,26 @@ module LinkedIn
       # Obtain profile information for a member.  Currently, the method only
       # accesses the authenticated user.
       #
-      # Permissions: r_liteprofile r_emailaddress
+      # Permissions: r_liteprofile
       #
       # @see https://docs.microsoft.com/en-us/linkedin/consumer/integrations/self-serve/sign-in-with-linkedin?context=linkedin/consumer/context#retrieving-member-profiles
       #
       # @return [void]
       def v2_profile
         path = '/me'
+        v2_get(path)
+      end
+
+      # Obtain email information for a member.  Currently, the method only
+      # accesses the authenticated user.
+      #
+      # Permissions: r_emailaddress
+      #
+      # @see https://docs.microsoft.com/en-us/linkedin/consumer/integrations/self-serve/sign-in-with-linkedin?context=linkedin/consumer/context#retrieving-member-email-address
+      #
+      # @return [void]
+      def v2_email_address
+        path = '/emailAddress?q=members&projection=(elements*(handle~))'
         v2_get(path)
       end
 

--- a/lib/linked_in/api/v2.rb
+++ b/lib/linked_in/api/v2.rb
@@ -15,8 +15,9 @@ module LinkedIn
       #
       # @return [void]
       def v2_profile
-        path = '/me'
-        v2_get(path)
+        fields = ['id', 'firstName', 'lastName', 'profilePicture(displayImage~:playableStreams)'] # Default fields
+        path = "/me?projection=(#{fields.join(',')})"
+        parse_profile_data v2_get(path)
       end
 
       # Obtain email information for a member.  Currently, the method only
@@ -29,7 +30,7 @@ module LinkedIn
       # @return [void]
       def v2_email_address
         path = '/emailAddress?q=members&projection=(elements*(handle~))'
-        v2_get(path)
+        JSON.parse(v2_get(path))['elements'][0]['handle~']['emailAddress']
       end
 
       # Share content for the authenticated user
@@ -98,6 +99,39 @@ module LinkedIn
             }
           }
           payload
+        end
+
+        def parse_profile_data(raw_json)
+          parsed_json = JSON.parse(raw_json)
+
+          data = {
+            'id' => parsed_json['id'],
+            'first_name' => parse_profile_localized_field(parsed_json, 'firstName'),
+            'last_name' => parse_profile_localized_field(parsed_json, 'lastName')
+          }
+
+          if !parsed_json['profilePicture'].nil? &&
+             !parsed_json['profilePicture']['displayImage~'].nil? &&
+             !parsed_json['profilePicture']['displayImage~']['elements'].nil? &&
+             !parsed_json['profilePicture']['displayImage~']['elements'].empty?
+            data['picture_url'] = parsed_json['profilePicture']['displayImage~']['elements'].last['identifiers'].first['identifier']
+          end
+
+          data
+        end
+
+        def parse_profile_localized_field(parsed_json, field_name)
+          return unless parse_profile_localized_field_available?(parsed_json, field_name)
+          parsed_json[field_name]['localized'][parse_profile_field_locale(parsed_json, field_name)]
+        end
+
+        def parse_profile_field_locale(parsed_json, field_name)
+          "#{parsed_json[field_name]['preferredLocale']['language']}_" \
+            "#{parsed_json[field_name]['preferredLocale']['country']}"
+        end
+
+        def parse_profile_localized_field_available?(parsed_json, field_name)
+          parsed_json[field_name] && parsed_json[field_name]['localized']
         end
     end
   end

--- a/spec/cases/v2_spec.rb
+++ b/spec/cases/v2_spec.rb
@@ -28,16 +28,24 @@ describe LinkedIn::Api::V2 do
   end
 
   describe '#v2_profile' do
-    let(:api_url) { 'https://api.linkedin.com/v2/me' }
+    let(:api_url) { 'https://api.linkedin.com/v2/me?projection=(id,firstName,lastName,profilePicture(displayImage~:playableStreams))' }
+    let(:profile_response_json) {
+      "{\"firstName\":{\"localized\":{\"en_US\":\"Mal\"},\"preferredLocale\":{\"country\":\"US\",\"language\":\"en\"}},\"lastName\":{\"localized\":{\"en_US\":\"Reynolds\"},\"preferredLocale\":{\"country\":\"US\",\"language\":\"en\"}},\"profilePicture\":{\"displayImage\":\"urn:li:digitalmediaAsset:C4D03AQH6G4DJiJMrvg\",\"displayImage~\":{\"elements\":[{\"artifact\":\"urn:li:digitalmediaMediaArtifact:(urn:li:digitalmediaAsset:C4D03AQH6G4DJiJMrvg,urn:li:digitalmediaMediaArtifactClass:profile-displayphoto-shrink_100_100)\",\"authorizationMethod\":\"PUBLIC\",\"data\":{\"com.linkedin.digitalmedia.mediaartifact.StillImage\":{\"storageSize\":{\"width\":100,\"height\":100},\"storageAspectRatio\":{\"widthAspect\":1.0,\"heightAspect\":1.0,\"formatted\":\"1.00:1.00\"},\"mediaType\":\"image/jpeg\",\"rawCodecSpec\":{\"name\":\"jpeg\",\"type\":\"image\"},\"displaySize\":{\"uom\":\"PX\",\"width\":100.0,\"height\":100.0},\"displayAspectRatio\":{\"widthAspect\":1.0,\"heightAspect\":1.0,\"formatted\":\"1.00:1.00\"}}},\"identifiers\":[{\"identifier\":\"https://upload.wikimedia.org/wikipedia/en/1/13/MalReynoldsFirefly.JPG?w=100\",\"file\":\"urn:li:digitalmediaFile:(urn:li:digitalmediaAsset:C4D03AQH6G4DJiJMrvg,urn:li:digitalmediaMediaArtifactClass:profile-displayphoto-shrink_100_100,0)\",\"index\":0,\"mediaType\":\"image/jpeg\",\"identifierType\":\"EXTERNAL_URL\",\"identifierExpiresInSeconds\":1560988800}]},{\"artifact\":\"urn:li:digitalmediaMediaArtifact:(urn:li:digitalmediaAsset:C4D03AQH6G4DJiJMrvg,urn:li:digitalmediaMediaArtifactClass:profile-displayphoto-shrink_200_200)\",\"authorizationMethod\":\"PUBLIC\",\"data\":{\"com.linkedin.digitalmedia.mediaartifact.StillImage\":{\"storageSize\":{\"width\":200,\"height\":200},\"storageAspectRatio\":{\"widthAspect\":1.0,\"heightAspect\":1.0,\"formatted\":\"1.00:1.00\"},\"mediaType\":\"image/jpeg\",\"rawCodecSpec\":{\"name\":\"jpeg\",\"type\":\"image\"},\"displaySize\":{\"uom\":\"PX\",\"width\":200.0,\"height\":200.0},\"displayAspectRatio\":{\"widthAspect\":1.0,\"heightAspect\":1.0,\"formatted\":\"1.00:1.00\"}}},\"identifiers\":[{\"identifier\":\"https://upload.wikimedia.org/wikipedia/en/1/13/MalReynoldsFirefly.JPG?w=200\",\"file\":\"urn:li:digitalmediaFile:(urn:li:digitalmediaAsset:C4D03AQH6G4DJiJMrvg,urn:li:digitalmediaMediaArtifactClass:profile-displayphoto-shrink_200_200,0)\",\"index\":0,\"mediaType\":\"image/jpeg\",\"identifierType\":\"EXTERNAL_URL\",\"identifierExpiresInSeconds\":1560988800}]},{\"artifact\":\"urn:li:digitalmediaMediaArtifact:(urn:li:digitalmediaAsset:C4D03AQH6G4DJiJMrvg,urn:li:digitalmediaMediaArtifactClass:profile-displayphoto-shrink_400_400)\",\"authorizationMethod\":\"PUBLIC\",\"data\":{\"com.linkedin.digitalmedia.mediaartifact.StillImage\":{\"storageSize\":{\"width\":400,\"height\":400},\"storageAspectRatio\":{\"widthAspect\":1.0,\"heightAspect\":1.0,\"formatted\":\"1.00:1.00\"},\"mediaType\":\"image/jpeg\",\"rawCodecSpec\":{\"name\":\"jpeg\",\"type\":\"image\"},\"displaySize\":{\"uom\":\"PX\",\"width\":400.0,\"height\":400.0},\"displayAspectRatio\":{\"widthAspect\":1.0,\"heightAspect\":1.0,\"formatted\":\"1.00:1.00\"}}},\"identifiers\":[{\"identifier\":\"https://upload.wikimedia.org/wikipedia/en/1/13/MalReynoldsFirefly.JPG?w=400\",\"file\":\"urn:li:digitalmediaFile:(urn:li:digitalmediaAsset:C4D03AQH6G4DJiJMrvg,urn:li:digitalmediaMediaArtifactClass:profile-displayphoto-shrink_400_400,0)\",\"index\":0,\"mediaType\":\"image/jpeg\",\"identifierType\":\"EXTERNAL_URL\",\"identifierExpiresInSeconds\":1560988800}]},{\"artifact\":\"urn:li:digitalmediaMediaArtifact:(urn:li:digitalmediaAsset:C4D03AQH6G4DJiJMrvg,urn:li:digitalmediaMediaArtifactClass:profile-displayphoto-shrink_800_800)\",\"authorizationMethod\":\"PUBLIC\",\"data\":{\"com.linkedin.digitalmedia.mediaartifact.StillImage\":{\"storageSize\":{\"width\":800,\"height\":800},\"storageAspectRatio\":{\"widthAspect\":1.0,\"heightAspect\":1.0,\"formatted\":\"1.00:1.00\"},\"mediaType\":\"image/jpeg\",\"rawCodecSpec\":{\"name\":\"jpeg\",\"type\":\"image\"},\"displaySize\":{\"uom\":\"PX\",\"width\":800.0,\"height\":800.0},\"displayAspectRatio\":{\"widthAspect\":1.0,\"heightAspect\":1.0,\"formatted\":\"1.00:1.00\"}}},\"identifiers\":[{\"identifier\":\"https://upload.wikimedia.org/wikipedia/en/1/13/MalReynoldsFirefly.JPG?w=800\",\"file\":\"urn:li:digitalmediaFile:(urn:li:digitalmediaAsset:C4D03AQH6G4DJiJMrvg,urn:li:digitalmediaMediaArtifactClass:profile-displayphoto-shrink_800_800,0)\",\"index\":0,\"mediaType\":\"image/jpeg\",\"identifierType\":\"EXTERNAL_URL\",\"identifierExpiresInSeconds\":1560988800}]}],\"paging\":{\"count\":10,\"start\":0,\"links\":[]}}},\"id\":\"123456\"}"
+    }
 
     context "when LinkedIn returns 201 status code" do
-      before { stub_request(:get, api_url) }
+      before { stub_request(:get, api_url).to_return(body: profile_response_json, status: 201) }
 
       it "should send a request" do
-        client.v2_profile
+        data = client.v2_profile
 
         expect(a_request(:get, api_url).with(headers: headers, body: nil)
         ).to have_been_made.once
+
+        expect(data['id']).to eq '123456'
+        expect(data['first_name']).to eq 'Mal'
+        expect(data['last_name']).to eq 'Reynolds'
+        expect(data['picture_url']).to eq 'https://upload.wikimedia.org/wikipedia/en/1/13/MalReynoldsFirefly.JPG?w=800' # grabs the last image
       end
     end
 
@@ -54,15 +62,20 @@ describe LinkedIn::Api::V2 do
 
   describe '#v2_email_address' do
     let(:api_url) { 'https://api.linkedin.com/v2/emailAddress?q=members&projection=(elements*(handle~))' }
+    let(:email_response_json) {
+      "{\"elements\":[{\"handle\":\"urn:li:emailAddress:123456\",\"handle~\":{\"emailAddress\":\"mal@blue.sun\"}}]}"
+    }
 
     context "when LinkedIn returns 201 status code" do
-      before { stub_request(:get, api_url) }
+      before { stub_request(:get, api_url).to_return(body: email_response_json, status: 201) }
 
       it "should send a request" do
-        client.v2_email_address
+        email = client.v2_email_address
 
         expect(a_request(:get, api_url).with(headers: headers, body: nil)
         ).to have_been_made.once
+
+        expect(email).to eq 'mal@blue.sun'
       end
     end
 

--- a/spec/cases/v2_spec.rb
+++ b/spec/cases/v2_spec.rb
@@ -52,6 +52,31 @@ describe LinkedIn::Api::V2 do
     end
   end
 
+  describe '#v2_email_address' do
+    let(:api_url) { 'https://api.linkedin.com/v2/emailAddress?q=members&projection=(elements*(handle~))' }
+
+    context "when LinkedIn returns 201 status code" do
+      before { stub_request(:get, api_url) }
+
+      it "should send a request" do
+        client.v2_email_address
+
+        expect(a_request(:get, api_url).with(headers: headers, body: nil)
+        ).to have_been_made.once
+      end
+    end
+
+    context 'when LinkedIn returns 403 status code' do
+      before { stub_request(:get, api_url).to_return(body: '{}', status: 403) }
+
+      it 'returns 403 status code' do
+        expect do
+          client.v2_email_address
+        end.to raise_error(LinkedIn::Errors::AccessDeniedError)
+      end
+    end
+  end
+
   describe '#v2_add_share' do
     let(:urn) { '1234567890' }
     let(:comment) { 'Testing, 1, 2, 3' }


### PR DESCRIPTION
Adds:
  * Default fields to the `/me` endpoint, which are now required by LinkedIn
  * Support for the v2 email address endpoint
  * Parsing of the raw JSON responses from me and email endpoints
  * Specs covering what was added above

My company needed this for our auth flows before the v2 deadline. It is very basic and I followed the existing patterns. I am up for changing any of this, as long as I can get the same information it exposes.