### PR TITLE
Add support to request image upload url and share image

### DIFF
--- a/lib/linked_in/api/v2.rb
+++ b/lib/linked_in/api/v2.rb
@@ -44,19 +44,101 @@ module LinkedIn
         v2_post(path, MultiJson.dump(share_payload(urn, share)))
       end
 
+      # Request an image updload URL for the authenticated user
+      #
+      # Permissions: w_member_share
+      #
+      # @see https://docs.microsoft.com/en-us/linkedin/consumer/integrations/self-serve/share-on-linkedin?context=linkedin/consumer/context#create-an-image-share
+      #
+      # @param [String] urn   User's URN (UID) returned from OAuth access token
+      #                       request
+      #
+      # @return [void]
+      def v2_request_image_upload_url(urn)
+        if !urn.instance_of?(String) || urn.empty?
+          raise LinkedIn::Errors::UnavailableError, 'LinkedIn API: URN required'
+        end
+
+        path = '/assets?action=registerUpload'
+        v2_post(path, MultiJson.dump(v2_request_image_upload_payload(urn)))
+      end
+
+      # Upload image asset from a requested image upload url
+      #
+      # Permissions: w_member_share
+      #
+      # @see https://docs.microsoft.com/en-us/linkedin/consumer/integrations/self-serve/share-on-linkedin?context=linkedin/consumer/context#upload-image-binary-file
+      #
+      # @param [String] url Url requested from `v2_request_image_upload_url`
+      # @param [Binary] body A Binary file Content
+      #
+      # @return [void]
+      def v2_upload_image(url, body)
+        v2_post(url, body, upload_file_headers)
+      end
+
       private
 
+        def upload_file_headers
+          {
+            'Content-type': 'application/octet-stream',
+            unscoped_url: true
+          }
+        end
+
         def share_payload(urn, share)
-          payload = { author: "urn:li:person:#{urn}",
+          visbility = share[:visibility] || 'PUBLIC'
+
+          payload = {
+            author: "urn:li:person:#{urn}",
             lifecycleState: 'PUBLISHED',
+            specificContent: {
+              'com.linkedin.ugc.ShareContent' => {
+                shareCommentary: { text: share[:comment] },
+                shareMediaCategory: 'NONE',
+              }
+            },
             visibility: {
-              'com.linkedin.ugc.MemberNetworkVisibility' => 'PUBLIC'
+              'com.linkedin.ugc.MemberNetworkVisibility' => visbility
             }
           }
 
           return add_url_to_payload(payload, share) if share[:url]
+          return add_image_to_payload(payload, share) if share[:image]
 
-          add_comment_to_payload(payload, share)
+          payload
+        end
+
+        def v2_request_image_upload_payload(urn)
+          {
+            registerUploadRequest: {
+              recipes: [
+                "urn:li:digitalmediaRecipe:feedshare-image"
+              ],
+              owner: "urn:li:person:#{urn}",
+              serviceRelationships: [
+                {
+                  relationshipType: "OWNER",
+                  identifier: "urn:li:userGeneratedContent"
+                }
+              ]
+            }
+          }
+        end
+
+        def add_image_to_payload(payload, share)
+          media = { status: 'READY', media: share[:image] }
+          if share[:description]
+            media[:description] = { text: share[:description] }
+          end
+          if share[:title]
+            media[:title] = { text: share[:title] }
+          end
+
+          payload[:specificContent]['com.linkedin.ugc.ShareContent'][:shareMediaCategory] = 'IMAGE'
+          payload[:specificContent]['com.linkedin.ugc.ShareContent'][:media] = [media]
+
+          payload
         end
 
         def add_url_to_payload(payload, share)
@@ -67,23 +149,10 @@ module LinkedIn
           if share[:title]
             media[:title] = { text: share[:title] }
           end
-          payload[:specificContent] = {
-            'com.linkedin.ugc.ShareContent' => {
-              shareCommentary: { text: share[:comment] },
-              shareMediaCategory: 'ARTICLE',
-              media: [media]
-            }
-          }
-          payload
-        end
 
-        def add_comment_to_payload(payload, share)
-          payload[:specificContent] = {
-            'com.linkedin.ugc.ShareContent' => {
-              shareCommentary: { text: share[:comment] },
-              shareMediaCategory: 'NONE'
-            }
-          }
+          payload[:specificContent]['com.linkedin.ugc.ShareContent'][:shareMediaCategory] = 'ARTICLE'
+          payload[:specificContent]['com.linkedin.ugc.ShareContent'][:media] = [media]
+
           payload
         end
     end

--- a/lib/linked_in/helpers/v2_request.rb
+++ b/lib/linked_in/helpers/v2_request.rb
@@ -21,11 +21,17 @@ module LinkedIn
         end
 
         def v2_post(path, body = '', options = {})
+          # unscoped_url option necessary for image updload
+          # Since Linkedin returns a complete URL for image upload on version 2 (unscoped from v2)
+          # we can't scope requests on v2 as well
+          # see: https://docs.microsoft.com/en-us/linkedin/consumer/integrations/self-serve/share-on-linkedin?context=linkedin/consumer/context#upload-image-binary-file
+          url = options.delete(:unscoped_url) ? path : "#{API_PATH}#{path}"
+
           options = { body: body, headers: DEFAULT_HEADERS.merge(options) }
           # response is OAuth2::Response
           # response.response is Faraday::Response
           # sending back response.response makes it easier to access the env
-          response = access_token.post("#{API_PATH}#{path}", options).response
+          response = access_token.post(url, options).response
           raise_errors(response)
           response
         end

--- a/spec/cases/v2_spec.rb
+++ b/spec/cases/v2_spec.rb
@@ -52,14 +52,119 @@ describe LinkedIn::Api::V2 do
     end
   end
 
+  describe "#v2_request_image_upload_url" do
+    let(:api_url) { 'https://api.linkedin.com/v2/assets?action=registerUpload' }
+    let(:urn) { '1234567890' }
+    let(:body) {
+      {
+        registerUploadRequest: {
+          recipes: [
+            "urn:li:digitalmediaRecipe:feedshare-image"
+          ],
+          owner: "urn:li:person:#{urn}",
+          serviceRelationships: [
+            {
+              relationshipType: "OWNER",
+              identifier: "urn:li:userGeneratedContent"
+            }
+          ]
+        }
+      }
+    }
+
+    before { stub_request(:post, api_url).to_return(body: '{}', status: 201) }
+
+    it "should send request" do
+      client.v2_request_image_upload_url(urn)
+
+      expect(a_request(:post, 'https://api.linkedin.com/v2/assets?action=registerUpload')
+        .with(body: body, headers: headers)
+      ).to have_been_made.once
+    end
+  end
+
+  describe "#v2_upload_image" do
+    let(:api_url) { "https://api.linkedin.com/mediaUpload/C5522AQGTYER3k3ByHQ/feedshare-uploadedImage/0?ca=vector_feedshare&cn=uploads&m=AQJbrN86Zm265gAAAWemyz2pxPSgONtBiZdchrgG872QltnfYjnMdb2j3A&app=1953784&sync=0&v=beta&ut=2H-IhpbfXrRow1" }
+    let(:body) { "\xFF\xD8\xFF\xE0\u0000\u0010J" }
+
+    let(:headers) do
+      {
+        'Accept'=>'*/*',
+        'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+        'Authorization'=>"Bearer #{token}",
+        'Content-Type' => 'application/octet-stream',
+        'User-Agent'=>'Faraday v0.15.4',
+        'X-Li-Format' => 'json',
+        'X-Restli-Protocol-Version' => '2.0.0'
+      }
+    end
+
+    before { stub_request(:post, api_url).to_return(body: '{}', status: 201) }
+
+    it "should send binay upload" do
+      client.v2_upload_image(api_url, body)
+
+      expect(a_request(:post, api_url)
+        .with(body: body, headers: headers)
+      ).to have_been_made.once
+    end
+  end
+
   describe '#v2_add_share' do
     let(:urn) { '1234567890' }
     let(:comment) { 'Testing, 1, 2, 3' }
     let(:url) { 'http://example.com/share' }
+    let(:image) { 'urn:li:digitalmediaAsset:C4D22AQHdunx-1RlagQ' }
     let(:title) { 'Foobar Title' }
     let(:body) do
       { author: "urn:li:person:#{urn}", lifecycleState: 'PUBLISHED',
         visibility: { 'com.linkedin.ugc.MemberNetworkVisibility' => 'PUBLIC' } }
+    end
+
+    context "when comment, image, and title" do
+      before do
+        body[:specificContent] = {
+          'com.linkedin.ugc.ShareContent' => {
+            shareCommentary: { text: comment },
+            media: [
+              { status: 'READY', media: image, title: { text: title } }
+            ],
+            shareMediaCategory: 'IMAGE'
+          }
+        }
+        stub_request(:post, 'https://api.linkedin.com/v2/ugcPosts')
+          .to_return(body: '{}', status: 201)
+      end
+
+      it "should send a request" do
+        client.v2_add_share(urn, comment: comment, image: image, title: title)
+
+        expect(a_request(:post, 'https://api.linkedin.com/v2/ugcPosts')
+          .with(body: body, headers: headers)
+        ).to have_been_made.once
+      end
+    end
+
+    context "when image and comment" do
+      before do
+        body[:specificContent] = {
+          'com.linkedin.ugc.ShareContent' => {
+            media: [{ status: 'READY', media: image }],
+            shareCommentary: { text: comment },
+            shareMediaCategory: 'IMAGE'
+          }
+        }
+        stub_request(:post, 'https://api.linkedin.com/v2/ugcPosts')
+          .to_return(body: '{}', status: 201)
+      end
+
+      it "should send a request" do
+        client.v2_add_share(urn, image: image, comment: comment)
+
+        expect(a_request(:post, 'https://api.linkedin.com/v2/ugcPosts')
+          .with(body: body, headers: headers)
+        ).to have_been_made.once
+      end
     end
 
     context "when comment only" do
@@ -85,6 +190,15 @@ describe LinkedIn::Api::V2 do
             .with(body: body, headers: headers)
           ).to have_been_made.once
         end
+
+        it "should send with different visibility" do
+          body[:visibility]['com.linkedin.ugc.MemberNetworkVisibility'] = "CONNECTIONS"
+          client.v2_add_share(urn, comment: comment, visibility: "CONNECTIONS")
+
+          expect(a_request(:post, 'https://api.linkedin.com/v2/ugcPosts')
+            .with(body: body, headers: headers)
+          ).to have_been_made.once
+        end
       end
 
       context "when LinkedIn returns 403 status code" do
@@ -105,10 +219,10 @@ describe LinkedIn::Api::V2 do
       before do
         body[:specificContent] = {
           'com.linkedin.ugc.ShareContent' => {
+            shareCommentary: { text: comment },
             media: [
               { status: 'READY', originalUrl: url, title: { text: title } }
             ],
-            shareCommentary: { text: comment },
             shareMediaCategory: 'ARTICLE'
           }
         }


### PR DESCRIPTION
Hey @dsandstrom 

I current company that I'm working on was looking to make image shares on version 2. I took the opportunity to fork your work and add some contributions to that. 

This PR adds support to request an image upload URL and send the image upload to be used in the post.

 - `v2_request_image_upload_url` requests the image uplaod url. see https://docs.microsoft.com/en-us/linkedin/consumer/integrations/self-serve/share-on-linkedin?context=linkedin/consumer/context#register-the-image
 - `v2_upload_image` uploads the image sending a binay content from a file ( A content from a `File#read` for instance). see https://docs.microsoft.com/en-us/linkedin/consumer/integrations/self-serve/share-on-linkedin?context=linkedin/consumer/context#upload-image-binary-file

Hope we can discuss this solution and put everything together in an official release.

